### PR TITLE
Update for install.sh for Telegram indicator

### DIFF
--- a/plugins/telegram.plugin/install.sh
+++ b/plugins/telegram.plugin/install.sh
@@ -2,4 +2,4 @@
 
 dnf copr -y enable rommon/telegram
 
-dnf -y install telegram-desktop
+dnf -y install telegram-desktop libappindicator


### PR DESCRIPTION
https://github.com/telegramdesktop/tdesktop/issues/491    (last 3 comments) 

According the "Telegram" issues list in GNOME desktop we gonna need "libappindicator" for systray option. Should we add this too in install or just make separation for it (GNOME only, Other DE(s) ) I don't know but we need this lib in order to make it work.

Thank you