### PR TITLE
Update metadata.json for masterpdfeditor to correctly detect package.

### DIFF
--- a/plugins/masterpdfeditor.plugin/metadata.json
+++ b/plugins/masterpdfeditor.plugin/metadata.json
@@ -13,6 +13,6 @@
 			"label": "Remove",
 			"command": "run-as-root dnf -y --setopt clean_requirements_on_remove=1 erase master-pdf-editor"
 		},
-		"status": { "command": "rpm --quiet --query master-pdf-editor" }
+		"status": { "command": "rpm --quiet --query master-pdf-editor3" }
 	}
 }


### PR DESCRIPTION
After installing Master PDF editor, fedy does not detect that it is installed.