### PR TITLE
Fixed Status issue

### DIFF
--- a/plugins/vivaldi.plugin/metadata.json
+++ b/plugins/vivaldi.plugin/metadata.json
@@ -13,6 +13,6 @@
 			"label": "Remove",
 			"command": "run-as-root dnf -y --setopt clean_requirements_on_remove=1 erase vivaldi-preview"
 		},
-		"status": { "command": "rpm --quiet --query vivaldi-preview" }
+		"status": { "command": "rpm --quiet --query vivaldi-beta" }
 	}
 }


### PR DESCRIPTION
Status now checks for vivaldi-beta instead of preview. Now status is properly checked.