### PR TITLE
Updated Numix repo

### DIFF
--- a/plugins/numix.plugin/install.sh
+++ b/plugins/numix.plugin/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dnf copr -y enable satya164/numix
+dnf copr -y enable numix/numix
 dnf -y install numix-icon-theme numix-icon-theme-circle numix-gtk-theme

--- a/plugins/numix.plugin/uninstall.sh
+++ b/plugins/numix.plugin/uninstall.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dnf copr -y disable satya164/numix
+dnf copr -y disable numix/numix
 dnf -y --setopt clean_requirements_on_remove=1 erase numix-icon-theme numix-icon-theme-circle numix-gtk-theme


### PR DESCRIPTION
I updated the Numix copr repository to the new one that has support for Fedora 23 and Rawhide.
Here's the link to the repo: https://copr.fedoraproject.org/coprs/numix/numix/ 
Link to the numix issue: https://github.com/numixproject/numix-copr/issues/1
Link to the fedy issue: https://github.com/folkswithhats/fedy/issues/300