### PR TITLE
Add Syncthing

### DIFF
--- a/plugins/syncthing.plugin/install.sh
+++ b/plugins/syncthing.plugin/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dnf copr -y enable decathorpe/syncthing
+dnf -y install syncthing syncthing-gtk

--- a/plugins/syncthing.plugin/metadata.json
+++ b/plugins/syncthing.plugin/metadata.json
@@ -1,0 +1,17 @@
+{
+	"label": "Syncthing",
+	"description": "Open Source Continuous File Synchronization.",
+	"license": ["MPLv2","GPLv2"],
+	"category": "Apps",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root -s uninstall.sh"
+		},
+		"status": { "command": "rpm --quiet --query syncthing syncthing-gtk" }
+	}
+}

--- a/plugins/syncthing.plugin/uninstall.sh
+++ b/plugins/syncthing.plugin/uninstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dnf -y --setopt clean_requirements_on_remove=1 erase syncthing syncthing-gtk
+dnf copr -y disable decathorpe/syncthing


### PR DESCRIPTION
for https://github.com/folkswithhats/fedy/issues/285

1. Install script enbles [copr repository](https://copr.fedoraproject.org/coprs/decathorpe/syncthing/) and installs packages `syncthing`, `syncthing-gtk` but services need to be enabled manually.
Use: 

        sudo systemctl enable syncthing@$USER.service
        sudo systemctl start syncthing@$USER.service
2. Uninstall script disables the copr repository but keeps `/etc/yum.repos.d/_copr_decathorpe-syncthing.repo`.