### PR TITLE
update to get latest build of Sublime Text 3

### DIFF
--- a/plugins/sublimetext.plugin/install.sh
+++ b/plugins/sublimetext.plugin/install.sh
@@ -11,7 +11,7 @@ fi
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL="http://c758482.r82.cf2.rackcdn.com/sublime_text_3_build_3083_${ARCH}.tar.bz2"
+URL="http://c758482.r82.cf2.rackcdn.com/$(wget http://www.sublimetext.com/3 -O - | grep -Po sublime_text_3_build_[0-9]{4}_$ARCH.tar.bz2)"
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
The old link would always download `build 3083` of Sublime Text 3; ie. file `sublime_text_3_build_3083_x32.tar.bz2` or  `sublime_text_3_build_3083_x64.tar.bz2` even if newer builds are available which is a little undesirable. 

The changes makes it possible to get the most current build of ST3 available on their website.