### PR TITLE
Use deadline for SSDs and HDDs

### DIFF
--- a/plugins/ioscheduler.plugin/metadata.json
+++ b/plugins/ioscheduler.plugin/metadata.json
@@ -1,7 +1,7 @@
 {
 	"icon": "drive-harddisk",
-	"label": "SSD I/O scheduler",
-	"description": "Switch to NOOP scheduler to boost performance for SSDs.",
+	"label": "Disk I/O Scheduler",
+	"description": "Switch to Deadline scheduler to boost performance for SSDs and HDDs.",
 	"category": "Tweaks",
 	"scripts": {
 		"exec": {

--- a/plugins/ioscheduler.plugin/setup.sh
+++ b/plugins/ioscheduler.plugin/setup.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-scheduler="noop"
+non-rotating-scheduler="deadline"
+rotating-scheduler="deadline"
 
 # Based on: https://wiki.archlinux.org/index.php/Solid_State_Drives
+# Reference for using deadline on SSDs: https://wiki.debian.org/SSDOptimization#Low-Latency_IO-Scheduler
 cat <<EOF | tee "/etc/udev/rules.d/60-io_schedulers.rules" > /dev/null 2>&1
 # Set noop scheduler for non-rotating disks
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="$scheduler"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="$non-rotating-scheduler"
 # Set deadline scheduler for rotating disks
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="deadline"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="$rotating-scheduler"
 EOF
 
 for disk in `\ls -d /sys/block/sd*`; do


### PR DESCRIPTION
In response to #295. 

According to the [Debian wiki](https://wiki.debian.org/SSDOptimization#Low-Latency_IO-Scheduler):
> The dumb "noop" scheduler may be a little faster in benchmarks that max out the throughput, but this scheduler causes noticeable delays for other tasks while large file transfers are in progress. 