### PR TITLE
changed the domain for the download of sublime

### DIFF
--- a/plugins/sublimetext.plugin/install.sh
+++ b/plugins/sublimetext.plugin/install.sh
@@ -11,7 +11,7 @@ fi
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL="http://c758482.r82.cf2.rackcdn.com/$(wget http://www.sublimetext.com/3 -O - | grep -Po sublime_text_3_build_[0-9]{4}_$ARCH.tar.bz2)"
+URL="http://download.sublimetext.com/$(wget http://www.sublimetext.com/3 -O - | grep -Po sublime_text_3_build_[0-9]{4}_$ARCH.tar.bz2)"
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
On February, 9th 2016 a new version of sublime-text 3 was released. After a fresh install of Fedora 23 x86_64 I wanted to install sublime and I got the following error: 

<pre><code>
-2016-02-09 17:06:22--  http://www.sublimetext.com/3
Resolving www.sublimetext.com (www.sublimetext.com)... 209.20.75.76
Connecting to www.sublimetext.com (www.sublimetext.com)|209.20.75.76|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 26199 (26K) [text/html]
Saving to: ‘STDOUT’

-                   100%[=====================>]  25.58K  32.2KB/s   in 0.8s   

2016-02-09 17:06:23 (32.2 KB/s) - written to stdout [26199/26199]

--2016-02-09 17:06:23--  http://c758482.r82.cf2.rackcdn.com/sublime_text_3_build_3103_x64.tar.bz2
Resolving c758482.r82.cf2.rackcdn.com (c758482.r82.cf2.rackcdn.com)... 61.213.151.42, 61.213.151.35, 2600:140e:1::17c9:6611, ...
Connecting to c758482.r82.cf2.rackcdn.com (c758482.r82.cf2.rackcdn.com)|61.213.151.42|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-02-09 17:06:25 ERROR 404: Not Found.


bzip2: Compressed file ends unexpectedly;
	perhaps it is corrupted?  *Possible* reason follows.
bzip2: Inappropriate ioctl for device
	Input file = (stdin), output file = (stdout)

It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.

You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.

tar: Child returned status 2
tar: Error is not recoverable: exiting now
Failed to show notification: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.Notifications was not provided by any .service files
</pre></code>

For me it looked like with the new releases there have been a few changes in the download-infrastructure of the [Sublime-Text website](https://www.sublimetext.com/3). 
So I just changed the server-address in the install script.