### PR TITLE
added files for gnome titlebar fix plugin

### DIFF
--- a/plugins/gnometitle.plugin/README.md
+++ b/plugins/gnometitle.plugin/README.md
@@ -1,0 +1,3 @@
+# fedy-gnome-titlebar-plugin
+
+Plugin for fedy which removes padding from Gnome's window title bars for the user.  Adds css file in user's home directory - does not modify gnome settings system-wide.

--- a/plugins/gnometitle.plugin/metadata.json
+++ b/plugins/gnometitle.plugin/metadata.json
@@ -10,7 +10,8 @@
 		},
 		"undo": {
 			"label": "Revert",
-			"command": "rm -f ~/.config/gtk-3.0/gtk.css"
+			"command": "sh ./revert.sh"
 		}
+		"status": { "command": "test if grep -q addedbyfedy ~/.config/gtk-3.0/gtk.css"  }
 	}
 }

--- a/plugins/gnometitle.plugin/metadata.json
+++ b/plugins/gnometitle.plugin/metadata.json
@@ -1,0 +1,16 @@
+{
+	"icon": "utilities-terminal",
+	"label": "Decrease Gnome Title Bar Size",
+	"description": "Decreases thickness of Gnome's default window title bars for the active user.",
+	"category": "Tweaks",
+	"scripts": {
+		"exec": {
+			"label": "Setup",
+			"command": "sh ./setup.sh"
+		},
+		"undo": {
+			"label": "Revert",
+			"command": "rm -f ~/.config/gtk-3.0/gtk.css"
+		}
+	}
+}

--- a/plugins/gnometitle.plugin/revert.sh
+++ b/plugins/gnometitle.plugin/revert.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #remove lines with matching string "addedbyfedy" and output new file
-grep -vwE "addedbyfedy" ~/.config/gtk-3.0/gtk.css > ~/.config/gtk-3.0/gtk.css
+sed -i '/addedbyfedy/d' ~/.config/gtk-3.0/gtk.css
 
 #restart gnome shell
 gnome-shell -r &

--- a/plugins/gnometitle.plugin/revert.sh
+++ b/plugins/gnometitle.plugin/revert.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#remove lines with matching string "addedbyfedy" and output new file
+grep -vwE "addedbyfedy" ~/.config/gtk-3.0/gtk.css > ~/.config/gtk-3.0/gtk.css
+
+#restart gnome shell
+gnome-shell -r &
+disown

--- a/plugins/gnometitle.plugin/setup.sh
+++ b/plugins/gnometitle.plugin/setup.sh
@@ -5,21 +5,26 @@ touch ~/.config/gtk-3.0/gtk.css
 
 #append css overrides
 cat <<EOF >> ~/.config/gtk-3.0/gtk.css
-.header-bar.default-decoration {
-        padding-top: 0px;
-        padding-bottom: 0px;
-    }
-
-.header-bar.default-decoration .button.titlebutton {
-    padding-top: 0px;
-    padding-bottom: 0px;
-}
-
-/* No line below the title bar */
-.ssd .titlebar {
-    border-width: 0;
-    box-shadow: none;
-}
+headerbar { /*addedbyfedy*/
+    min-height: 38px; /*addedbyfedy*/
+    padding-left: 2px; /*addedbyfedy*/
+    padding-right: 2px; /*addedbyfedy*/
+} /*addedbyfedy*/
+headerbar entry, /*addedbyfedy*/
+headerbar spinbutton, /*addedbyfedy*/
+headerbar button, /*addedbyfedy*/
+headerbar separator { /*addedbyfedy*/
+    margin-top: 2px; /*addedbyfedy*/
+    margin-bottom: 2px; /*addedbyfedy*/
+} /*addedbyfedy*/
+.default-decoration { /*addedbyfedy*/
+    min-height: 0; /*addedbyfedy*/
+    padding: 2px /*addedbyfedy*/
+} /*addedbyfedy*/
+.default-decoration .titlebutton { /*addedbyfedy*/
+    min-height: 26px; /*addedbyfedy*/
+    min-width: 26px; /*addedbyfedy*/
+} /*addedbyfedy*/
 EOF
 
 #restart gnome shell

--- a/plugins/gnometitle.plugin/setup.sh
+++ b/plugins/gnometitle.plugin/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# create css file
+touch ~/.config/gtk-3.0/gtk.css
+
+#append css overrides
+cat <<EOF >> ~/.config/gtk-3.0/gtk.css
+.header-bar.default-decoration {
+        padding-top: 0px;
+        padding-bottom: 0px;
+    }
+
+.header-bar.default-decoration .button.titlebutton {
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
+/* No line below the title bar */
+.ssd .titlebar {
+    border-width: 0;
+    box-shadow: none;
+}
+EOF
+
+#restart gnome shell
+gnome-shell -r &
+disown

--- a/plugins/gnometitle.plugin/setup.sh
+++ b/plugins/gnometitle.plugin/setup.sh
@@ -3,7 +3,7 @@
 # create css file
 touch ~/.config/gtk-3.0/gtk.css
 
-#append css overrides
+#append css overrides with tags for removal later without removing entire file
 cat <<EOF >> ~/.config/gtk-3.0/gtk.css
 headerbar { /*addedbyfedy*/
     min-height: 38px; /*addedbyfedy*/

--- a/plugins/gtkhidpi.plugin/README.md
+++ b/plugins/gtkhidpi.plugin/README.md
@@ -1,0 +1,3 @@
+# fedy-gnome-titlebar-plugin
+
+Plugin for fedy which removes padding from Gnome's window title bars for the user.  Adds css file in user's home directory - does not modify gnome settings system-wide.

--- a/plugins/gtkhidpi.plugin/metadata.json
+++ b/plugins/gtkhidpi.plugin/metadata.json
@@ -1,0 +1,17 @@
+{
+	"icon": "utilities-terminal",
+	"label": "Decrease Gnome Title Bar Size",
+	"description": "Decreases thickness of Gnome's default window title bars for the active user.",
+	"category": "Tweaks",
+	"scripts": {
+		"exec": {
+			"label": "Setup",
+			"command": "sh ./setup.sh"
+		},
+		"undo": {
+			"label": "Revert",
+			"command": "sh ./revert.sh"
+		}
+		"status": { "command": "test if grep -q addedbyfedy ~/.config/gtk-3.0/gtk.css"  }
+	}
+}

--- a/plugins/gtkhidpi.plugin/revert.sh
+++ b/plugins/gtkhidpi.plugin/revert.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#remove lines with matching string "addedbyfedy" and output new file
+sed -i '/addedbyfedy/d' ~/.config/gtk-3.0/gtk.css
+
+#restart gnome shell
+gnome-shell -r &
+disown

--- a/plugins/gtkhidpi.plugin/setup.sh
+++ b/plugins/gtkhidpi.plugin/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# create css file
+touch ~/.config/gtk-3.0/gtk.css
+
+#append css overrides with tags for removal later without removing entire file
+cat <<EOF >> ~/.config/gtk-3.0/gtk.css
+headerbar { /*addedbyfedy*/
+    min-height: 38px; /*addedbyfedy*/
+    padding-left: 2px; /*addedbyfedy*/
+    padding-right: 2px; /*addedbyfedy*/
+} /*addedbyfedy*/
+headerbar entry, /*addedbyfedy*/
+headerbar spinbutton, /*addedbyfedy*/
+headerbar button, /*addedbyfedy*/
+headerbar separator { /*addedbyfedy*/
+    margin-top: 2px; /*addedbyfedy*/
+    margin-bottom: 2px; /*addedbyfedy*/
+} /*addedbyfedy*/
+.default-decoration { /*addedbyfedy*/
+    min-height: 0; /*addedbyfedy*/
+    padding: 2px /*addedbyfedy*/
+} /*addedbyfedy*/
+.default-decoration .titlebutton { /*addedbyfedy*/
+    min-height: 26px; /*addedbyfedy*/
+    min-width: 26px; /*addedbyfedy*/
+} /*addedbyfedy*/
+EOF
+
+#restart gnome shell
+gnome-shell -r &
+disown


### PR DESCRIPTION
Plugin to remove padding from gnome's overly thick titlebars.  Creates a css file in the user's home directory which overrides system-wide settings, so can be used on a per-user basis.  I still need to find a better way of reverting the changes created, in case the user has already added their own css overrides, as of right now the "undo" simply deletes the file in ~/.config/gtk-3.0/
