### PR TITLE
Update install.sh for plugins/arctheme.plugin/ for Fedora 24

### DIFF
--- a/plugins/arctheme.plugin/install.sh
+++ b/plugins/arctheme.plugin/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
+if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") = 24 ]]; then
+  dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
+else
+  dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo
+fi
 dnf -y install arc-theme

--- a/plugins/arctheme.plugin/install.sh
+++ b/plugins/arctheme.plugin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") = 24 ]]; then
+if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") -ge 24 ]]; then
   dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
 else
   dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo

--- a/plugins/arctheme.plugin/install.sh
+++ b/plugins/arctheme.plugin/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo
+dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
 dnf -y install arc-theme


### PR DESCRIPTION
Update install.sh for plugins/arctheme.plugin/ for Fedora 24

Here is what the new repo download link should look like:
http://download.opensuse.org/repositories/home:Horst3180/Fedora_24_standard/home:Horst3180.repo