### PR TITLE
Update install.sh for plugins/arcthemesolid.plugin/ for Fedora 24

### DIFF
--- a/plugins/arcthemesolid.plugin/install.sh
+++ b/plugins/arcthemesolid.plugin/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo
+dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
 dnf -y install arc-theme-solid

--- a/plugins/arcthemesolid.plugin/install.sh
+++ b/plugins/arcthemesolid.plugin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") = 24 ]]; then
+if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") -ge 24 ]]; then
   dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
 else
   dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo

--- a/plugins/arcthemesolid.plugin/install.sh
+++ b/plugins/arcthemesolid.plugin/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
+if [[ $(cat /etc/fedora-release | grep -o "[0-9]*") = 24 ]]; then
+  dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")_standard/home:Horst3180.repo
+else
+  dnf config-manager --add-repo=http://download.opensuse.org/repositories/home:Horst3180/Fedora_$(cat /etc/fedora-release | grep -o "[0-9]*")/home:Horst3180.repo
+fi
 dnf -y install arc-theme-solid


### PR DESCRIPTION
Update install.sh for plugins/arcthemesolid.plugin/ for Fedora 24

Repo download path changed for Fedora 24:
http://download.opensuse.org/repositories/home:Horst3180/Fedora_24_standard/home:Horst3180.repo