### PR TITLE
Add the powerline plugin

### DIFF
--- a/plugins/powerline.plugin/install.sh
+++ b/plugins/powerline.plugin/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+dnf list installed powerline || run-as-root dnf -y install powerline
+
+# See comments on https://fedoramagazine.org/add-power-terminal-powerline/
+
+mkdir ~/.config/powerline
+cat > ~/.config/powerline/config.json <<'EOF'
+{
+  "ext": {
+    "shell": {
+      "theme": "default_leftonly"
+        }
+    }
+}
+EOF
+
+grep powerline ~/.bashrc || cat >> ~/.bashrc <<'EOF'
+
+# If powerline is installed and the terminal supports it
+# (e.g. ttys have problems with Powerline fonts), start it
+if command -v powerline-daemon &> /dev/null && [[ $TERM == xterm* ]]; then
+    powerline-daemon -q
+    POWERLINE_BASH_CONTINUATION=1
+    POWERLINE_BASH_SELECT=1
+    . /usr/share/powerline/bash/powerline.sh
+fi
+EOF

--- a/plugins/powerline.plugin/metadata.json
+++ b/plugins/powerline.plugin/metadata.json
@@ -1,0 +1,17 @@
+{
+	"icon": "utilities-terminal",
+	"label": "Powerline",
+	"description": "Powerful, flexible and beautiful bash prompt.",
+	"category": "Tweaks",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "bash install.sh"
+		},
+		"undo": {
+			"label": "Uninstall",
+			"command": "bash uninstall.sh"
+		},
+		"status": { "command": "bash status.sh" }
+	}
+}

--- a/plugins/powerline.plugin/status.sh
+++ b/plugins/powerline.plugin/status.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+exec test -e ~/.config/powerline

--- a/plugins/powerline.plugin/uninstall.sh
+++ b/plugins/powerline.plugin/uninstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -rf ~/.config/powerline
+# leave ~/.bashrc as is
+run-as-root dnf -y remove powerline


### PR DESCRIPTION
Though powerline's available in the Fedora repos, it requires some configuration to set up. [Add power to your terminal with powerline](https://fedoramagazine.org/add-power-terminal-powerline/) is of some help (esp. the comments), but I still had to figure a lot of stuff out.

This is meant to be the ultimate solution to installing powerline as a bash prompt. I'd be glad if someone familiar with setting it up for use with vim, tmux, etc would come and implement that.

Please do review the scripts as I'm bad at scripting in bash.
