### PR TITLE
Install Numix from official Fedora repository

### DIFF
--- a/plugins/numix.plugin/install.sh
+++ b/plugins/numix.plugin/install.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-dnf copr -y enable numix/numix
 dnf -y install numix-icon-theme numix-icon-theme-circle numix-gtk-theme

--- a/plugins/numix.plugin/uninstall.sh
+++ b/plugins/numix.plugin/uninstall.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-dnf copr -y disable numix/numix
 dnf -y --setopt clean_requirements_on_remove=1 erase numix-icon-theme numix-icon-theme-circle numix-gtk-theme


### PR DESCRIPTION
Use official Fedora repo instead of copr to install Numix theme. To me, it still make sense to keep Numix installation in Fedy as I cannot find it in GNOME Software.