### PR TITLE
Add Arc Icon Theme

### DIFF
--- a/plugins/arcicontheme.plugin/install.sh
+++ b/plugins/arcicontheme.plugin/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dnf copr -y enable user501254/Arc
+dnf -y install arc-icon-theme

--- a/plugins/arcicontheme.plugin/metadata.json
+++ b/plugins/arcicontheme.plugin/metadata.json
@@ -1,0 +1,17 @@
+{
+	"label": "Arc Icon Theme",
+	"description": "A flat icon theme to accompany the Arc GTK theme.",
+	"license": "GPLv3",
+	"category": "Themes",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root -s uninstall.sh"
+		},
+		"status": { "command": "rpm --quiet --query arc-icon-theme" }
+	}
+}

--- a/plugins/arcicontheme.plugin/metadata.json
+++ b/plugins/arcicontheme.plugin/metadata.json
@@ -1,6 +1,6 @@
 {
 	"label": "Arc Icon Theme",
-	"description": "A flat icon theme to accompany the Arc GTK theme.",
+	"description": "A flat icon theme.",
 	"license": "GPLv3",
 	"category": "Themes",
 	"scripts": {

--- a/plugins/arcicontheme.plugin/uninstall.sh
+++ b/plugins/arcicontheme.plugin/uninstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dnf copr -y disable user501254/Arc
+dnf -y --setopt clean_requirements_on_remove=1 erase arc-icon-theme


### PR DESCRIPTION
A flat icon theme to accompany the Arc GTK theme.

Makes use of [this Copr Repository](https://copr.fedorainfracloud.org/coprs/user501254/Arc/).
On commits, SRPM packages are submitted to Copr on fixed intervals, the script and spec file can be found in [this repository](https://github.com/user501254/packaging).
The Copr repository also provides `moka-icon-theme` & `faba-icon-theme` which is used by the `arc-icon-theme` in case of missing application icons.


This would close #392.