### PR TITLE
Review of existing plugins

### DIFF
--- a/plugins/codecs.plugin/metadata.json
+++ b/plugins/codecs.plugin/metadata.json
@@ -7,12 +7,12 @@
 	"scripts": {
 		"exec": {
 			"label": "Install",
-			"command": "run-as-root dnf -y install fedy-multimedia-codecs"
+			"command": "run-as-root dnf -y groupinstall multimedia"
 		},
 		"undo": {
 			"label": "Remove",
-			"command": "run-as-root dnf -y remove fedy-multimedia-codecs"
+			"command": "run-as-root dnf -y remove gstreamer1-libav"
 		},
-		"status": { "command": "rpm --quiet --query fedy-multimedia-codecs" }
+		"status": { "command": "rpm --quiet --query gstreamer1-libav" }
 	}
 }

--- a/plugins/flash-ppapi.plugin/install.sh
+++ b/plugins/flash-ppapi.plugin/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+dnf -y install http://linuxdownload.adobe.com/adobe-release/adobe-release-$(uname -i)-1.0-1.noarch.rpm
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-adobe-linux
+dnf -y install flash-player-ppapi

--- a/plugins/flash-ppapi.plugin/metadata.json
+++ b/plugins/flash-ppapi.plugin/metadata.json
@@ -1,0 +1,18 @@
+{
+	"icon": "flash",
+	"label": "Adobe Flash (ppapi)",
+	"description": "Adobe Flash Player PPAPI for chromium based browsers",
+	"license": "Proprietary",
+	"category": "Utilities",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root dnf -y remove flash-player-ppapi"
+		},
+		"status": { "command": "rpm --quiet --query flash-player-ppapi" }
+	}
+}

--- a/plugins/flash.plugin/metadata.json
+++ b/plugins/flash.plugin/metadata.json
@@ -1,7 +1,7 @@
 {
 	"icon": "flash",
-	"label": "Adobe Flash",
-	"description": "Browser plug-in and rich Internet application runtime.",
+	"label": "Adobe Flash (npapi)",
+	"description": "Browser plug-in and rich Internet application runtime for npapi enabled browser (firefox, etc)",
 	"license": "Proprietary",
 	"category": "Utilities",
 	"scripts": {

--- a/plugins/flash.plugin/metadata.json
+++ b/plugins/flash.plugin/metadata.json
@@ -11,7 +11,7 @@
 		},
 		"undo": {
 			"label": "Remove",
-			"command": "run-as-root dnf -y remove flash-plugin adobe-release"
+			"command": "run-as-root dnf -y remove flash-plugin"
 		},
 		"status": { "command": "rpm --quiet --query flash-plugin" }
 	}

--- a/plugins/handbrake.plugin/install.sh
+++ b/plugins/handbrake.plugin/install.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-dnf config-manager --add-repo=http://negativo17.org/repos/fedora-multimedia.repo
-dnf -y install HandBrake-gui

--- a/plugins/handbrake.plugin/metadata.json
+++ b/plugins/handbrake.plugin/metadata.json
@@ -6,11 +6,11 @@
 	"scripts": {
 		"exec": {
 			"label": "Install",
-			"command": "run-as-root -s install.sh"
+			"command": "run-as-root dnf install HandBrake-gui"
 		},
 		"undo": {
 			"label": "Remove",
-			"command": "run-as-root -s uninstall.sh"
+			"command": "run-as-root dnf remove HandBrake-gui"
 		},
 		"status": { "command": "rpm --quiet --query HandBrake-gui" }
 	}

--- a/plugins/handbrake.plugin/uninstall.sh
+++ b/plugins/handbrake.plugin/uninstall.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-dnf -y erase HandBrake-gui
-rm -f /etc/yum.repos.d/fedora-multimedia.repo

--- a/plugins/libdvdcss.plugin/install.sh
+++ b/plugins/libdvdcss.plugin/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dnf -y config-manager --add-repo=http://negativo17.org/repos/fedora-multimedia.repo
+dnf -y install http://rpm.livna.org/livna-release.rpm
 dnf -y install libdvdcss

--- a/plugins/oraclevirtualbox-guest.plugin/metadata.json
+++ b/plugins/oraclevirtualbox-guest.plugin/metadata.json
@@ -1,0 +1,18 @@
+{
+	"icon": "virtualbox",
+	"label": "VirtualBox-guest",
+	"description": "Tools to install guest additions in VirtualBox",
+	"license": "GPLv2",
+	"category": "Apps",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root dnf -y install VirtualBox-guest-additions akmod-VirtualBox kernel-devel-uname-r"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root dnf -y remove VirtualBox-guest-additions akmod-VirtualBox"
+		},
+		"status": { "command": "rpm --quiet --query VirtualBox-guest-additions" }
+	}
+}

--- a/plugins/oraclevirtualbox.plugin/install.sh
+++ b/plugins/oraclevirtualbox.plugin/install.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-dnf -y install binutils gcc make patch libgomp glibc-headers glibc-devel kernel-headers kernel-devel dkms
-
-dnf -y install VirtualBox VirtualBox-guest-additions akmod-VirtualBox

--- a/plugins/oraclevirtualbox.plugin/metadata.json
+++ b/plugins/oraclevirtualbox.plugin/metadata.json
@@ -7,11 +7,11 @@
 	"scripts": {
 		"exec": {
 			"label": "Install",
-			"command": "run-as-root -s install.sh"
+			"command": "run-as-root dnf -y install VirtualBox akmod-VirtualBox kernel-devel-uname-r"
 		},
 		"undo": {
 			"label": "Remove",
-			"command": "run-as-root dnf -y remove VirtualBox VirtualBox-guest-additions akmod-VirtualBox"
+			"command": "run-as-root dnf -y remove VirtualBox akmod-VirtualBox"
 		},
 		"status": { "command": "rpm --quiet --query VirtualBox" }
 	}

--- a/plugins/steam.plugin/install.sh
+++ b/plugins/steam.plugin/install.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-dnf -y install steam
-
-# Make "Big picture" mode work
-setsebool -P allow_execheap 1

--- a/plugins/steam.plugin/metadata.json
+++ b/plugins/steam.plugin/metadata.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"exec": {
 			"label": "Install",
-			"command": "run-as-root -s install.sh"
+			"command": "run-as-root dnf -y install steam"
 		},
 		"undo": {
 			"label": "Remove",


### PR DESCRIPTION
This is a partial review of existing plugins to verify compatibility and avoid mistake and possible error.

From this review:
- Remove dependencies with conflicting repository
- Fix VirtualBox module, one cannot install the guest and hyp on the same host
- Use a dedicated plugin for flash ppapi (chromium based)
- Rely on multimedia group to have a more accurate codecs installation

Looking at the way repo/software are dealt with, I think it should be better to have a dedicated plugin for each repository (copr, *-release or else). Then have software to add a dependency on the repo plugin. If 

There are also lot of binary software that are installed into /opt whereas they could be installed into a user specific directory. It's not a big issue, but those would be candidates for flatpak...