### PR TITLE
Install libXScrnSaver with GitKraken

### DIFF
--- a/plugins/gitkraken.plugin/install.sh
+++ b/plugins/gitkraken.plugin/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+dnf -y install libXScrnSaver
+
 CACHEDIR="/var/cache/fedy/gitkraken";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"


### PR DESCRIPTION
libXScrnSaver is a required dependency that is not installed by default on Fedora 26. If this library is not present then GitKraken will fail to start with the error: "error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory"