### PR TITLE
Add Postman plugin

### DIFF
--- a/plugins/postman.plugin/install.sh
+++ b/plugins/postman.plugin/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+CACHEDIR="/var/cache/fedy/postman";
+mkdir -p "$CACHEDIR"
+cd "$CACHEDIR"
+
+if [[ "$(uname -m)" = "x86_64" ]]; then
+	ARCH="64"
+else
+	ARCH="32"
+fi
+
+URL="https://dl.pstmn.io/download/latest/linux$ARCH"
+FILE=${URL##*/}
+
+wget -c "$URL" -O "$FILE"
+
+if [[ ! -f "$FILE" ]]; then
+	exit 1
+fi
+
+tar -xzf "$FILE" -C "/opt/"
+ln -sf "/opt/Postman/Postman" "/usr/bin/postman"
+
+cp "/opt/Postman/resources/app/assets/icon.png" "/usr/share/icons/hicolor/128x128/apps/postman.png"
+gtk-update-icon-cache -f -t /usr/share/icons/hicolor
+
+cat <<EOF | tee /usr/share/applications/postman.desktop
+[Desktop Entry]
+Name=Postman
+Type=Application
+Exec=postman
+Icon=postman
+Comment=The most complete toolchain for API developers
+Categories=Development;
+Keywords=Postman;API;REST;Testing;
+StartupNotify=true
+Terminal=false
+StartupWMClass=postman
+EOF

--- a/plugins/postman.plugin/metadata.json
+++ b/plugins/postman.plugin/metadata.json
@@ -1,0 +1,19 @@
+{
+	"icon": "postman",
+	"label": "Postman",
+	"description": "The most complete toolchain for API developers.",
+	"license": "Freeware",
+	"proprietary": true,
+	"category": "Development Tools",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root -s uninstall.sh"
+		},
+		"status": { "command": "test -f /opt/Postman/Postman" }
+	}
+}

--- a/plugins/postman.plugin/postman.png
+++ b/plugins/postman.plugin/postman.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f832a403f05a742750be79717ade72606ee707f3580f613936d03a790b50cb0d
+size 6167

--- a/plugins/postman.plugin/uninstall.sh
+++ b/plugins/postman.plugin/uninstall.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+rm "/usr/share/icons/hicolor/128x128/apps/postman.png"
+gtk-update-icon-cache -f -t /usr/share/icons/hicolor
+
+rm -f "/usr/bin/postman"
+rm -f "/usr/share/applications/postman.desktop"
+rm -rf "/opt/Postman"


### PR DESCRIPTION
I used JetBrains Toolbox as an example and haven't done a Fedy plugin before so let me know if there's any problems.

Current method results in the app installed at `/opt/Postman`, and the `.desktop` file installed as per other plugins. Have tested only on Fedora 26 (including clean install).

---

There seems to be some difference between plugins using `/var/cache/fedy/<app-name>` vs using `/tmp` for temp files. Is there a standard, or any docs?