### PR TITLE
Updated Sublime Text Version Status

### DIFF
--- a/plugins/sublimetext.plugin/metadata.json
+++ b/plugins/sublimetext.plugin/metadata.json
@@ -1,7 +1,7 @@
 {
 	"icon": "sublime-text-3",
 	"label": "Sublime Text 3",
-	"description": "Sophisticated text editor for code, markup and prose (beta).",
+	"description": "Sophisticated text editor for code, markup and prose.",
 	"license": "Proprietary",
 	"category": "Development Tools",
 	"scripts": {

--- a/plugins/sublimetext2.plugin/metadata.json
+++ b/plugins/sublimetext2.plugin/metadata.json
@@ -1,7 +1,7 @@
 {
 	"icon": "sublime-text-2",
-	"label": "Sublime Text 2",
-	"description": "Sophisticated text editor for code, markup and prose. (deprecated)",
+	"label": "Sublime Text 2 (Deprecated)",
+	"description": "Sophisticated text editor for code, markup and prose.",
 	"proprietary": true,
 	"category": "Development Tools",
 	"scripts": {

--- a/plugins/sublimetext2.plugin/metadata.json
+++ b/plugins/sublimetext2.plugin/metadata.json
@@ -1,7 +1,7 @@
 {
 	"icon": "sublime-text-2",
 	"label": "Sublime Text 2",
-	"description": "Sophisticated text editor for code, markup and prose.",
+	"description": "Sophisticated text editor for code, markup and prose. (deprecated)",
 	"proprietary": true,
 	"category": "Development Tools",
 	"scripts": {


### PR DESCRIPTION
* Marked Sublime Text 2 as deprecated. Not officially deprecated, but no longer updated and new users will purchased Sublime Text 3 licenses that are not compatible with Sublime Text 2.
* Marked Sublime Text 3 as stable. Removing the `(beta)` tag from the description.